### PR TITLE
use exit code 1 instead of 128

### DIFF
--- a/dirty.sh
+++ b/dirty.sh
@@ -2,12 +2,12 @@
 
 if test -n "$(git status --porcelain)"; then
   echo 'Unclean working tree. Commit or stash changes first.' >&2;
-  exit 128;
+  exit 1;
 fi
 
 if ! git fetch --quiet 2> /dev/null; then
   echo 'There was a problem fetching your branch.' >&2;
-  exit 128;
+  exit 1;
 fi
 
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -16,7 +16,7 @@ git branch --set-upstream-to=origin/"$BRANCH" "$BRANCH" > /dev/null
 
 if test "0" != "$(git rev-list --count --left-only @'{u}'...HEAD)"; then
   echo 'Remote history differ. Please pull changes.' >&2;
-  exit 128;
+  exit 1;
 fi
 
 git branch --unset-upstream


### PR DESCRIPTION
Hi @Kikobeats!

This is a handy module. Thanks for making it!

I think the error code you're using is invalid. The `128` error code is reserved for `Invalid argument to exit`. Please see http://tldp.org/LDP/abs/html/exitcodes.html for reference. I changed it to `1` in my fork.
